### PR TITLE
Better argument handling and changes to filter argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ The following arguments modify this behavior:
  
 
 # Change Log
+2017-7-18
+- Better parsing of command line arguments
+- Fixed sizeof filter bug
+- Bump version to v1.6 (c) @MuntashirAkon @HeavenVolkoff 
+
 2017-7-17
 - Added `--filter` option
 - Added help in case of providing an invalid argument
-- Code improvements
-- Bump version to v1.6 (c) @MuntashirAkon 
+- Code improvements 
 
 2017-6-22
 - Added `--stream` option

--- a/maclog.h
+++ b/maclog.h
@@ -22,7 +22,7 @@
 //
 #include <sys/sysctl.h>
 //
-// for time
+// for time(...)
 //
 #include <time.h>
 #include <string.h>
@@ -30,6 +30,11 @@
 // for access to old ASL logging system
 //
 #include <asl.h>
+//
+// for getopt_long(...)
+// more info: http://man7.org/linux/man-pages/man3/getopt.3.html
+//
+#include <getopt.h>
 
 //
 // Power Management's ASL keys
@@ -59,12 +64,33 @@
 #define gLogPath "/tmp/system.log"
 
 //
-// constants for gLogArgs, for mkaing them easy to change and increase readability
+// argument flags
+//
+#define shortOptions "bdf:hsSvw"
+struct option longOptions[] = {
+    {"boot",        no_argument,        NULL,   'b'},
+    {"darkWake",    no_argument,        NULL,   'd'},
+    {"filter",      required_argument,  NULL,   'f'},
+    {"help",        no_argument,        NULL,   'h'},
+    {"sleep",       no_argument,        NULL,   's'},
+    {"stream",      no_argument,        NULL,   'S'},
+    {"version",     no_argument,        NULL,   'v'},
+    {"wake",        no_argument,        NULL,   'w'},
+    {0,             0,                  0,       0 },
+};
+
+//
+// constants for gLogArgs, for making them easy to change and increase readability
 //
 #define gLogCommand 1
 #define gLogTime    9
 #define gLogFilter  3
 
+//
+// filter
+//
+#define predicate "(process == \"kernel\" OR eventMessage CONTAINS[c] \"kernel\")"
+#define filterConcat " AND "
 
 //
 // get log argv
@@ -73,7 +99,7 @@ char *gLogArgs[] = {
         "log",
         NULL,
         "--predicate",
-        NULL,
+        predicate,
         "--style",
         "syslog",
         "--source",

--- a/maclog.m
+++ b/maclog.m
@@ -143,11 +143,75 @@ void prepareLogArgv(int type) {
     }
 }
 
+void printHelpAndExit (int exitStatus) {
+    printf(
+            "USAGE: maclog [--version|-v] [--help|-h]\n"
+            "USAGE: maclog [logMode] [-f|--filter=<query>]\n"
+            "Arguments:\n"
+            " --help,     -h  Show maclog help info.\n"
+            " --version,  -v  Show maclog version info.\n"
+            "Log Modes:\n"
+            " --boot,     -b  Show log messages since last boot time.\n"
+            " --darkWake, -d  Show log messages since last darkWake time.\n"
+            " --sleep,    -s  Show log messages since last sleep time.\n"
+            " --stream,   -S  Show log messages in real time.\n"
+            " --wake,     -w  Show log messages since last wake time.\n"
+            "Filter:\n"
+            " --filter,   -f  Show log messages filtered by the <query>.\n"
+            "NOTE: The default behaviour is to show all log messages of the current day.\n"
+            "NOTE: The messages returned by \e[1m--boot\e[0m, \e[1m--sleep\e[0m, "
+            "\e[1m--wake\e[0m, \e[1m--darkWake\e[0m can be from previous days,"
+            " depending on the last time each action occurred.\n"
+            "NOTE: The \e[1m--stream\e[0m option results in the maclog process being never finished,"
+            " due to the necessity of redirecting all logs to Console in real-time.\n"
+    );
+    exit(exitStatus);
+}
+
 int main(int argc, char **argv)
 {
+    int mode = 0;
+    int filterFlag = 0;
+    int optionIndex = 0;
+    int currentOption = getopt_long (argc, argv, shortOptions, longOptions, &optionIndex);
+
+    //
+    // Handle arguments
+    //
+    while (currentOption != -1)
+    {
+        switch (currentOption) {
+            case 'f':
+                if (filterFlag) {
+                    printf("ERROR: Filter argument should only appear once.\n");
+                    exit(EXIT_FAILURE);
+                }
+
+                filterFlag = 1;
+                gLogArgs[gLogFilter] = calloc(sizeof(predicate filterConcat) + strlen(optarg) + 1, sizeof(char));
+                sprintf(gLogArgs[gLogFilter], predicate filterConcat "%s", optarg);
+                break;
+            case 'h':
+                printHelpAndExit(EXIT_SUCCESS);
+            case 'v':
+                printf("v%.1f (c) 2017 syscl/lighting/Yating Zhou\n", PROGRAM_VER);
+                exit(EXIT_SUCCESS);
+            case '?':
+                printHelpAndExit(EXIT_FAILURE);
+            default:
+                if (mode) {
+                    printf("ERROR: Different modes can't be mixed.\n");
+                    printHelpAndExit(EXIT_FAILURE);
+                }
+
+                mode = currentOption;
+                break;
+        }
+
+        currentOption = getopt_long (argc, argv, shortOptions, longOptions, &optionIndex);
+    }
+
     pid_t rc;
-    char default_str[] = "(process == \"kernel\" OR eventMessage CONTAINS[c] \"kernel\")";
-    char filter_str[]  = " AND eventMessage CONTAINS[c] \"";
     if ((rc = fork()) > 0)
     {
         //
@@ -158,104 +222,44 @@ int main(int argc, char **argv)
         // create the log file
         //
         int fd = open(gLogPath, O_CREAT | O_TRUNC | O_RDWR, PERMS);
-        
-        //
-        // Handle arguments
-        //
-        
-        //
-        // get filter
-        //
-        switch (argc) {
-            case 3:
-                if (strcmp(argv[1], "--filter") == 0 || strcmp(argv[1], "-f") == 0) {
-                    gLogArgs[gLogFilter] = (char *)malloc(sizeof(char) * 2 + sizeof(default_str) + sizeof(filter_str) + sizeof(argv[2]));
-                    sprintf(gLogArgs[gLogFilter], "%s%s%s\"", default_str, filter_str, argv[2]);
-                }
+
+        switch (mode) {
+            case 0:
+                prepareLogArgv(showLogArgv);
+                gLogArgs[gLogTime] = gCurTime();
                 break;
-            case 4:
-                if (strcmp(argv[2], "--filter") == 0 || strcmp(argv[2], "-f") == 0) {
-                    gLogArgs[gLogFilter] = (char *)malloc(sizeof(char) * 2 + sizeof(default_str) + sizeof(filter_str) + sizeof(argv[3]));
-                    sprintf(gLogArgs[gLogFilter], "%s%s%s\"", default_str, filter_str, argv[3]);
-                }
+            case 'b':
+                prepareLogArgv(showLogArgv);
+                gLogArgs[gLogTime] = gBootTime();
+                break;
+            case 'd':
+                prepareLogArgv(showLogArgv);
+                gLogArgs[gLogTime] = gPowerManagerDomainTime(kPMASLDomainPMDarkWake);
+                break;
+            case 's':
+                prepareLogArgv(showLogArgv);
+                gLogArgs[gLogTime] = gPowerManagerDomainTime(kPMASLDomainPMSleep);
+                break;
+            case 'S':
+                prepareLogArgv(streamLogArgv);
+                break;
+            case 'w':
+                prepareLogArgv(showLogArgv);
+                gLogArgs[gLogTime] = gPowerManagerDomainTime(kPMASLDomainPMWake);
                 break;
             default:
-                gLogArgs[gLogFilter] = default_str;
-                break;
+                if(access(gLogPath, F_OK) == 0) unlink(gLogPath);
+                printf("ERROR: Invalid mode: %c\n", mode);
+                printHelpAndExit(EXIT_FAILURE);
         }
-        //
-        // get option
-        //
-        if (argc > 1)
-        {
-            if (strcmp(argv[1], "--stream") == 0 || strcmp(argv[1], "-S") == 0) {
-                prepareLogArgv(streamLogArgv);
-            } else {
-                prepareLogArgv(showLogArgv);
-                if (strcmp(argv[1], "--boot") == 0 || strcmp(argv[1], "-b") == 0)
-                {
-                    gLogArgs[gLogTime] = gBootTime();
-                }
-                else if (strcmp(argv[1], "--sleep") == 0 || strcmp(argv[1], "-s") == 0)
-                {
-                    gLogArgs[gLogTime] = gPowerManagerDomainTime(kPMASLDomainPMSleep);
-                    
-//                    for(int i=0; i<11; i++) printf("%s, ", gLogArgs[i]);
-//                    return EXIT_SUCCESS;
-                }
-                else if (strcmp(argv[1], "--wake") == 0 || strcmp(argv[1], "-w") == 0)
-                {
-                    gLogArgs[gLogTime] = gPowerManagerDomainTime(kPMASLDomainPMWake);
-                }
-                else if (strcmp(argv[1], "--darkWake") == 0 || strcmp(argv[1], "-d") == 0)
-                {
-                    gLogArgs[gLogTime] = gPowerManagerDomainTime(kPMASLDomainPMDarkWake);
-                }
-                else if(strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-v") == 0){
-                    if(access(gLogPath, F_OK) == 0) unlink(gLogPath);
-                    printf("v%.1f (c) 2017 syscl/lighting/Yating Zhou\n", PROGRAM_VER);
-                    exit(EXIT_SUCCESS);
-                }
-                else
-                {
-                    // TODO: need more improvement, sorry for being so lazy!
-                    if(argc != 3 && argc != 4){
-                        if(access(gLogPath, F_OK) == 0) unlink(gLogPath);
-                        printf(
-                               "Invalid argument(s).\n"
-                               "USAGE: maclog [option] [-f|--filter <query>]\n"
-                               " --boot, -b     Show log messages since last boot time.\n"
-                               " --darkWake, -d Show log messages since last darkWake time.\n"
-                               " --filter, -f   Show log messages filtered by the <query>.\n"
-                               " --stream, -S   Show log messages in real time.\n"
-                               " --sleep, -s    Show log messages since last sleep time.\n"
-                               " --version, -v  Show this maclog version info.\n\n"
-                               " --wake, -w     Show log messages since last wake time.\n"
-                               "NOTE: The default behaviour is to show all log messages of the current day.\n"
-                               "NOTE: The messages returned by \e[1m--boot\e[0m, \e[1m--sleep\e[0m, "
-                               "\e[1m--wake\e[0m, \e[1m--darkWake\e[0m can be from previous days,"
-                               " depending on the last time each action occurred.\n"
-                               "NOTE: The \e[1m--stream\e[0m option results in the maclog process being never finished,"
-                               " due to the necessity of redirecting all logs to Console in real-time.\n"
-                               );
-                        exit(EXIT_FAILURE);
-                    }
-                    gLogArgs[gLogTime] = gCurTime();
-                }
-            }
-        }
-        else
-        {
-            prepareLogArgv(showLogArgv);
-            gLogArgs[gLogTime] = gCurTime();
-        }
+
         //
         // log the log file
         //
         if (fd >= 0)
         {
             if (dup2(fd, STDOUT_FILENO) < 0) {
-                printf("Failed to retrieve logs.\n");
+                printf("ERROR: Failed to retrieve logs.\n");
                 exit(EXIT_FAILURE);
             }
         }
@@ -278,7 +282,7 @@ int main(int argc, char **argv)
         //
         // fork failed
         //
-        printf("Fork failed\n");
+        printf("ERROR: Fork failed\n");
         return EXIT_FAILURE;
     }
 

--- a/maclog.m
+++ b/maclog.m
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
                 }
 
                 filterFlag = 1;
-                gLogArgs[gLogFilter] = calloc(sizeof(predicate filterConcat) + strlen(optarg) + 1, sizeof(char));
+                gLogArgs[gLogFilter] = calloc(sizeof(predicate filterConcat) + strlen(optarg), sizeof(char));
                 sprintf(gLogArgs[gLogFilter], predicate filterConcat "%s", optarg);
                 break;
             case 'h':


### PR DESCRIPTION
Hi,
I saw your pull request (great job by the way) and as it is still open I thought it would be better to merge this changes to your fork instead of opening another one at @syscl repo.

I implemented a better way to parse the command line arguments using `getopt_long`.
I also changed the argument of `--filter`, basically I removed the `eventMessage CONTAINS[c] \"` from the code, because I think this way it allows us to use any kind of predicate, instead of just the `eventMessage`.
And I modified the help message